### PR TITLE
Fixes issue #245 add a glossary term for chroot

### DIFF
--- a/docs/contributors/contribute-docs.md
+++ b/docs/contributors/contribute-docs.md
@@ -47,16 +47,31 @@ pull request.
 ### Directory structure
 
 All the documentation files are located in the `docs/` directory. The `docs/`
-directory contains sub-directories corresponding to different
-[Diátaxis](https://diataxis.fr/) sections:
+directory contains sub-directories according to the type of content.
 
-* `explanation/`
-* `howto/`
-* `reference/`
-* `tutorial/`
+All content is written and split according to the principles of
+[Diátaxis](https://diataxis.fr/). It is then organised for our readers
+according to who is using it, and how. Every task, every process, has at least
+two people involved: someone who is *contributing* something, and a maintainer
+who is responsible for reviewing it.
 
-Add new articles in the appropriate directory. You can read about
-[how Ubuntu implements Diátaxis for documentation](https://ubuntu.com/blog/diataxis-a-new-foundation-for-canonical-documentation).
+For contributors, we have:
+
+* **How Ubuntu is made**: Information about Ubuntu and how it's made,
+  the processes involved, and concepts contributors need to understand
+
+* **Contributors**: Guides and instructions for submitting or requesting
+  changes, fixes and new packages
+
+For maintainers, we have:
+
+* **Maintainers**: Guides for those with elevated permissions who review and
+  approve changes, new packages, and maintaining the health of the
+  Package Archive. 
+
+* **Who makes Ubuntu**: Information about all the people, roles and groups
+  involved in making Ubuntu, as well as their collective responsibilities and
+  how to join each of the roles.
 
 ## Build the documentation locally
 

--- a/docs/contributors/contribute-docs.md
+++ b/docs/contributors/contribute-docs.md
@@ -61,16 +61,16 @@ For contributors, we have:
   the processes involved, and concepts contributors need to understand
 
 * **Contributors**: Guides and instructions for submitting or requesting
-  changes, fixes and new packages
+  changes, fixes, and new packages
 
 For maintainers, we have:
 
 * **Maintainers**: Guides for those with elevated permissions who review and
-  approve changes, new packages, and maintaining the health of the
+  approve changes, new packages, and maintain the health of the
   Package Archive. 
 
-* **Who makes Ubuntu**: Information about all the people, roles and groups
-  involved in making Ubuntu, as well as their collective responsibilities and
+* **Who makes Ubuntu**: Information about all the people, roles, and groups
+  involved in making Ubuntu, as well as their collective responsibilities, and
   how to join each of the roles.
 
 ## Build the documentation locally

--- a/docs/contributors/contribute-docs.md
+++ b/docs/contributors/contribute-docs.md
@@ -50,7 +50,7 @@ All the documentation files are located in the `docs/` directory. The `docs/`
 directory contains sub-directories according to the type of content.
 
 All content is written and split according to the principles of
-[Diátaxis](https://diataxis.fr/). It is then organised for our readers
+[Diátaxis](https://diataxis.fr/). It is then organized for our readers
 according to who is using it, and how. Every task, every process, has at least
 two people involved: someone who is *contributing* something, and a maintainer
 who is responsible for reviewing it.

--- a/docs/how-ubuntu-is-made/concepts/glossary.md
+++ b/docs/how-ubuntu-is-made/concepts/glossary.md
@@ -269,6 +269,10 @@ Changelog
     * [Basic overview of the `debian/` directory](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/latest/reference/debian-dir-overview/)
     * [Section 4.4 Debian changelog (Debian Policy Manual v4.6.2.0)](https://www.debian.org/doc/debian-policy/ch-source.html#debian-changelog-debian-changelog)
 
+Chroot
+Change root
+    Sets the root directory to the path provided as its first argument.
+
 CoF
 Circle of Friends
     The {term}`Ubuntu` logo is called **Circle of Friends**, because it is


### PR DESCRIPTION
I hope you find this to be a concise and meaningful definition and if not I look forward to your feedback. This definition has left me with a few questions. 
Should there be glossary terms for path, root directory and arguments?  
Should chroot be lower case always? I notice that diff is in the glossary in lower case but I'm not sure if that's the house style. 
Is there a better place for me to ask/suggest this stuff?